### PR TITLE
Only iterate over the poller if a poll has been run

### DIFF
--- a/lib/zm/reactor.rb
+++ b/lib/zm/reactor.rb
@@ -518,11 +518,11 @@ module ZMQMachine
         sleep(@poll_interval / 1000.0)
       else
         rc = @poller.poll @poll_interval
-      end
 
-      if ZMQ::Util.resultcode_ok?(rc)
-        @poller.readables.each { |sock| @raw_to_socket[sock].resume_read }
-        @poller.writables.each { |sock| @raw_to_socket[sock].resume_write }
+        if ZMQ::Util.resultcode_ok?(rc)
+          @poller.readables.each { |sock| @raw_to_socket[sock].resume_read }
+          @poller.writables.each { |sock| @raw_to_socket[sock].resume_write }
+        end
       end
 
       rc


### PR DESCRIPTION
Currently if there are no sockets, the poll is not run. 
This means that the `@poller.readables` or `@poller.writeables` are from the previous poll and include any closed sockets. 

I changed the code so the iteration is only run if the poll is actually run. 
