### PR TITLE
Fix ZM::Deferrable#timeout by requiring a class to implement #reactor

### DIFF
--- a/lib/zm/deferrable.rb
+++ b/lib/zm/deferrable.rb
@@ -169,7 +169,9 @@ module ZMQMachine
       
       # we use milliseconds, not seconds, so adjust the passed in time
       seconds *= 1000
-      @deferred_timeout = ZMQMachine::Timers.add_oneshot seconds {me.fail(*args)}
+      @deferred_timeout = reactor.oneshot_timer seconds do
+        me.fail(*args)
+      end
     end
 
     # Cancels an outstanding timeout if any. Undoes the action of #timeout.
@@ -204,6 +206,7 @@ module ZMQMachine
   # as a way of communicating deferred status to some other part of a program.
   class DefaultDeferrable
     include Deferrable
+    attr_accessor :reactor
   end
 
 end # module ZMQMachine

--- a/lib/zm/reactor.rb
+++ b/lib/zm/reactor.rb
@@ -449,6 +449,14 @@ module ZMQMachine
       end
     end
 
+    # Returns a deferrable connected to this Reactor
+    #
+    def default_deferrable
+      deferrable = ZM::DefaultDeferrable.new
+      deferrable.reactor = self
+      deferrable
+    end
+
     # Publishes log messages to an existing transport passed in to the Reactor
     # constructor using the :log_endpoint key.
     #


### PR DESCRIPTION
Currently the `#timeout` method seems to be entirely busted. 
I have changed the method to depend on an instance method `#reactor` which should return the reactor to schedule timeouts against. 

Also, I added a method on `ZM::Reactor` to return a `ZM::DefaultDeferrable` which is connected to the reactor. 
